### PR TITLE
Add sleep to avoid race condition between services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,11 +22,15 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
-    entrypoint: ["/bin/sh", "-c"]
-    command: >
-      PGPASSWORD=postgres
-      psql "postgresql://postgres@postgres:5432/rag" -v ON_ERROR_STOP=1
-      -c "CREATE EXTENSION IF NOT EXISTS vector;"
+    entrypoint: >
+      /bin/sh -c "
+        set -ex
+        echo 'Aguardando o Postgres estar 100% pronto...'
+        sleep 5
+        echo 'Criando a extensão vector...'
+        PGPASSWORD=postgres psql 'postgresql://postgres@postgres:5432/rag' -v ON_ERROR_STOP=1 -c 'CREATE EXTENSION IF NOT EXISTS vector;'
+        echo 'Extensão criada com sucesso!'
+      "
     restart: "no"
 
 volumes:


### PR DESCRIPTION
This pull request addresses a race condition between the postgres and bootstrap_vector_ext services in the Docker Compose setup.

Changes
Added a sleep delay in the bootstrap_vector_ext service entrypoint to ensure that Postgres is fully ready before attempting to create the vector extension.
Improved logging for the extension creation process, providing clearer feedback in the container logs.
Maintained the healthcheck and dependency configuration to ensure proper service startup order.
Motivation
Previously, the bootstrap_vector_ext service could attempt to create the vector extension before Postgres was fully initialized, resulting in intermittent failures. By adding a short sleep and explicit readiness messages, this PR makes the extension creation more reliable and easier to debug.

Impact
Reduces the likelihood of startup failures due to service race conditions.
Improves observability of the extension creation process in logs.
No changes to application logic or database schema.